### PR TITLE
Support multiple handlers dealing with the same command

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.CommandHandling/ICommandHandlerResolver.cs
+++ b/src/Be.Vlaanderen.Basisregisters.CommandHandling/ICommandHandlerResolver.cs
@@ -1,12 +1,9 @@
 namespace Be.Vlaanderen.Basisregisters.CommandHandling
 {
-    using System;
     using System.Collections.Generic;
 
     public interface ICommandHandlerResolver
     {
-        ReturnHandler<CommandMessage<TCommand>> Resolve<TCommand>() where TCommand : class;
-
-        IEnumerable<Type> KnownCommandTypes { get; }
+        List<ReturnHandler<CommandMessage<TCommand>>> Resolve<TCommand>() where TCommand : class;
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.CommandHandling.Tests/CommandHandlerResolverTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.CommandHandling.Tests/CommandHandlerResolverTests.cs
@@ -164,7 +164,7 @@ namespace Be.Vlaanderen.Basisregisters.CommandHandling.Tests
             var module = new BadlyConfiguredCommandHandlerModule();
             var resolver = new CommandHandlerResolver(module);
 
-            Func<Task<long>> dispatch = async ()=>await resolver.Dispatch(Guid.NewGuid(), new Command());
+            Func<Task<long[]>> dispatch = async ()=> await resolver.Dispatch(Guid.NewGuid(), new Command());
 
             dispatch.ShouldThrowAsync<ApplicationException>($"No handler was found for command {typeof(Command).FullName}");
         }

--- a/test/Be.Vlaanderen.Basisregisters.CommandHandling.Tests/CommandHandlerResolverTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.CommandHandling.Tests/CommandHandlerResolverTests.cs
@@ -192,14 +192,30 @@ namespace Be.Vlaanderen.Basisregisters.CommandHandling.Tests
         }
 
         [Fact]
-        public void When_add_duplicate_command_then_should_throw()
+        public void When_add_duplicate_command_then_should_not_throw()
         {
             var module1 = new TestCommandHandlerModule();
             var module2 = new TestCommandHandlerModule2();
 
             Action act = () => new CommandHandlerResolver(module1, module2);
 
-            act.ShouldThrow<InvalidOperationException>();
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public async Task When_add_duplicate_command_then_should_handle_both()
+        {
+            var module1 = new TestCommandHandlerModule();
+            var module2 = new TestCommandHandlerModule2();
+            var resolver = new CommandHandlerResolver(module1, module2);
+
+            await resolver.Dispatch(Guid.NewGuid(), new Command());
+
+            module1.BaseCommandCounter.ShouldBe(1);
+            module1.CommandCounter.ShouldBe(1);
+
+            module2.BaseCommandCounter.ShouldBe(1);
+            module2.CommandCounter.ShouldBe(1);
         }
     }
 }


### PR DESCRIPTION
In the original implementation trying to do the following was not possible:

```csharp
private class CommandHandlerModule1 : CommandHandlerModule
{
    public int CommandCounter;

    public CommandHandlerModule1()
    {
        For<Command>()
            .Handle((_, __) => Task.FromResult((long) CommandCounter++));
    }
}

private class CommandHandlerModule2 : CommandHandlerModule
{
    public int CommandCounter;

    public CommandHandlerModule2()
    {
        For<Command>()
            .Handle((_, __) => Task.FromResult((long) CommandCounter++));
    }
}
```

This would throw an `InvalidOperationException` saying ` Attempt to register multiple handlers for command type Command`.

This doesn't make sense. Separation wise I like to create multiple `CommandHandlerModule`s which do something completely different with a command.

I've changed to code to allow multiple `CommandHandlerModule`s to deal with the same command, while still remaining async. I added two tests as well to verify the correct behavior.

There is another check like this in the `CommandHandlerModule` itself which prevents multiple `For`'s to listen to the same. I'm fine with leaving this one since you are already in the context/mindset of the class.

```csharp
public virtual ICommandHandlerBuilder<CommandMessage<TCommand>> For<TCommand>()
    where TCommand : class
    => new CommandHandlerBuilder<TCommand>(handlerRegistration =>
    {
        if (!HandlerRegistrations.Add(handlerRegistration))
            throw new InvalidOperationException(
                "Attempt to register multiple handlers for command type {0}".FormatWith(typeof(TCommand)));
    });
```

I would make this into a breaking change because multiple handlers mean they can return multiple results (the `long`). While this is not used here, it is probably used upstream which will need to be changed to decide what to do with multiple results (pick the lowest/highest).

PS: About the _why_ a handler needs to return a `long`, that's not part for this PR :)