### PR TITLE
fix: restore snapshot use version instead of position

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.AggregateSource.SqlStreamStore/Repository.cs
+++ b/src/Be.Vlaanderen.Basisregisters.AggregateSource.SqlStreamStore/Repository.cs
@@ -177,7 +177,7 @@ namespace Be.Vlaanderen.Basisregisters.AggregateSource.SqlStreamStore
                     var snapshotData = snapshotContainer.Data;
 
                     hydrateContainer.ReadFrom =
-                        (int)snapshotContainer.Info.Position + 1; // TODO: Fix this when SSS supports longs for read
+                        (int)snapshotContainer.Info.StreamVersion + 1; // TODO: Fix this when SSS supports longs for read
                     hydrateContainer.Snapshot = EventDeserializer.DeserializeObject(snapshotData, snapshotType);
                 }
             }
@@ -207,7 +207,7 @@ namespace Be.Vlaanderen.Basisregisters.AggregateSource.SqlStreamStore
                     var snapshotData = snapshotContainer.Data;
 
                     hydrateContainer.ReadFrom =
-                        (int)snapshotContainer.Info.Position + 1; // TODO: Fix this when SSS supports longs for read
+                        (int)snapshotContainer.Info.StreamVersion + 1; // TODO: Fix this when SSS supports longs for read
                     hydrateContainer.Snapshot = EventDeserializer.DeserializeObject(snapshotData, snapshotType);
                 }
             }

--- a/src/Be.Vlaanderen.Basisregisters.AggregateSource/Snapshotting/SnapshotInfo.cs
+++ b/src/Be.Vlaanderen.Basisregisters.AggregateSource/Snapshotting/SnapshotInfo.cs
@@ -2,7 +2,7 @@ namespace Be.Vlaanderen.Basisregisters.AggregateSource.Snapshotting
 {
     public class SnapshotInfo
     {
-        public long Position { get; set; }
+        public long StreamVersion { get; set; }
 
         public string Type { get; set; }
     }

--- a/src/Be.Vlaanderen.Basisregisters.AggregateSource/Snapshotting/SnapshotStrategyContext.cs
+++ b/src/Be.Vlaanderen.Basisregisters.AggregateSource/Snapshotting/SnapshotStrategyContext.cs
@@ -8,18 +8,15 @@ namespace Be.Vlaanderen.Basisregisters.AggregateSource.Snapshotting
         public Aggregate Aggregate { get; }
         public ImmutableList<EventWithMetadata> Events { get; }
         public int StreamVersion { get; }
-        public long SnapshotPosition { get; }
 
         public SnapshotStrategyContext(
             Aggregate aggregate,
             ImmutableList<EventWithMetadata> events,
-            int streamVersion,
-            long snapshotPosition)
+            int streamVersion)
         {
             Aggregate = aggregate ?? throw new ArgumentNullException(nameof(aggregate));
             Events = events ?? throw new ArgumentNullException(nameof(events));
             StreamVersion = streamVersion;
-            SnapshotPosition = snapshotPosition;
         }
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.CommandHandling.SqlStreamStore/AddSqlStreamStorePipe.cs
+++ b/src/Be.Vlaanderen.Basisregisters.CommandHandling.SqlStreamStore/AddSqlStreamStorePipe.cs
@@ -87,8 +87,7 @@ namespace Be.Vlaanderen.Basisregisters.CommandHandling.SqlStreamStore
                     new SnapshotStrategyContext(
                         aggregate,
                         events,
-                        result.CurrentVersion,
-                        result.CurrentPosition),
+                        result.CurrentVersion),
                     streamStore,
                     getSnapshotStore?.Invoke(),
                     uow,
@@ -127,7 +126,7 @@ namespace Be.Vlaanderen.Basisregisters.CommandHandling.SqlStreamStore
                 Info =
                 {
                     Type = eventMapping.GetEventName(snapshot.GetType()),
-                    Position = context.SnapshotPosition
+                    StreamVersion = context.StreamVersion
                 }
             };
 
@@ -141,7 +140,7 @@ namespace Be.Vlaanderen.Basisregisters.CommandHandling.SqlStreamStore
                     uow.GetSnapshotIdentifier(context.Aggregate.Identifier),
                     ExpectedVersion.Any,
                     new NewStreamMessage(
-                        Deterministic.Create(Deterministic.Namespaces.Events, $"snapshot-{context.SnapshotPosition}"),
+                        Deterministic.Create(Deterministic.Namespaces.Events, $"snapshot-{context.Aggregate.Identifier}-{context.StreamVersion}"),
                         $"SnapshotContainer<{snapshotContainer.Info.Type}>",
                         eventSerializer.SerializeObject(snapshotContainer)),
                     ct);

--- a/test/Be.Vlaanderen.Basisregisters.AggregateSource.SqlStreamStore.Tests/Framework/RepositoryScenarioBuilder.cs
+++ b/test/Be.Vlaanderen.Basisregisters.AggregateSource.SqlStreamStore.Tests/Framework/RepositoryScenarioBuilder.cs
@@ -77,13 +77,13 @@ namespace Be.Vlaanderen.Basisregisters.AggregateSource.SqlStreamStore.Tests.Fram
             return this;
         }
 
-        public Repository<T> BuildForRepository<T>()
-            where T : AggregateRootEntityStub, new ()
+        public Repository<T> BuildForRepository<T>(bool withNewUnitOfWork = false)
+            where T : AggregateRootEntityStub, new()
         {
             ExecuteScheduledActions();
             return new Repository<T>(
                 () => new T(),
-                _unitOfWork,
+                withNewUnitOfWork ? new ConcurrentUnitOfWork() : _unitOfWork,
                 _eventStore,
                 _eventMapping,
                 _eventDeserializer);

--- a/test/Be.Vlaanderen.Basisregisters.AggregateSource.SqlStreamStore.Tests/RepositoryTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.AggregateSource.SqlStreamStore.Tests/RepositoryTests.cs
@@ -314,13 +314,15 @@ namespace Be.Vlaanderen.Basisregisters.AggregateSource.SqlStreamStore.Tests
             {
                 Info =
                 {
-                    Position = 4,
+                    StreamVersion = 4,
                     Type = typeof(SnapshotStub).AssemblyQualifiedName
                 },
                 Data = eventSerializer.SerializeObject(new SnapshotStub(1))
             };
 
             _sut = new RepositoryScenarioBuilder(eventMapping, eventDeserializer)
+                .ScheduleAppendToStream(_model.UnknownIdentifier, new EventStub(0))
+                .ScheduleAppendToStream(_model.UnknownIdentifier, new EventStub(1))
                 .ScheduleAppendToStream(_model.KnownIdentifier, new EventStub(0))
                 .ScheduleAppendToStream(_model.KnownIdentifier, new EventStub(1))
                 .ScheduleAppendToStream(_model.KnownIdentifier, new EventStub(2))
@@ -329,7 +331,7 @@ namespace Be.Vlaanderen.Basisregisters.AggregateSource.SqlStreamStore.Tests
                 .ScheduleAppendToStream($"{_model.KnownIdentifier}-snapshots", snapshotContainer)
                 .ScheduleAppendToStream(_model.KnownIdentifier, new EventStub(5))
                 .ScheduleAppendToStream(_model.KnownIdentifier, new EventStub(6))
-                .BuildForRepository<AggregateRootEntitySnapshotableStub>();
+                .BuildForRepository<AggregateRootEntitySnapshotableStub>(true);
         }
 
         [Test]

--- a/test/Be.Vlaanderen.Basisregisters.AggregateSource.Tests/Snapshotting/NoSnapshotStrategyTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.AggregateSource.Tests/Snapshotting/NoSnapshotStrategyTests.cs
@@ -10,7 +10,7 @@ namespace Be.Vlaanderen.Basisregisters.AggregateSource.Tests.Snapshotting
         public void NeverTakeSnapshot()
         {
             var strategy = (ISnapshotStrategy)new NoSnapshotStrategy();
-            var ctx = new SnapshotStrategyContext(new Aggregate("1", 1, new AggregateRootEntityStub()), ImmutableList<EventWithMetadata>.Empty, 1, 0);
+            var ctx = new SnapshotStrategyContext(new Aggregate("1", 1, new AggregateRootEntityStub()), ImmutableList<EventWithMetadata>.Empty, 1);
             var result = strategy.ShouldCreateSnapshot(ctx);
 
             Assert.False(result);


### PR DESCRIPTION
BREAKING CHANGE:
- SnapshotStrategyContext no longer has SnapshotPosition
- SnapShotInfo Position renamed to StreamVersion